### PR TITLE
hw/riscv/tk1.c: update to new HTIF API

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -20,6 +20,7 @@
 #include "qemu/cutils.h"
 #include "hw/riscv/tk1.h"
 #include "qapi/error.h"
+#include "qemu/error-report.h"
 #include "hw/boards.h"
 #include "hw/misc/unimp.h"
 #include "hw/riscv/boot.h"
@@ -497,7 +498,8 @@ static void tk1_board_init(MachineState *machine)
     }
 
     riscv_load_firmware(machine->firmware, memmap[TK1_ROM].base, htif_symbol_callback);
-    htif_mm_init(sys_mem, &s->rom, &s->cpus.harts[0].env, serial_hd(0));
+    // TODO old htif_mm_init call, not longer workable
+    // htif_mm_init(sys_mem, &s->rom, &s->cpus.harts[0].env, serial_hd(0));
 }
 
 static void tk1_machine_instance_init(Object *obj)

--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -498,8 +498,7 @@ static void tk1_board_init(MachineState *machine)
     }
 
     riscv_load_firmware(machine->firmware, memmap[TK1_ROM].base, htif_symbol_callback);
-    // TODO old htif_mm_init call, not longer workable
-    // htif_mm_init(sys_mem, &s->rom, &s->cpus.harts[0].env, serial_hd(0));
+    htif_mm_init(sys_mem, serial_hd(0), 0, 0);
 }
 
 static void tk1_machine_instance_init(Object *obj)

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -521,15 +521,19 @@ static void riscv_host_cpu_init(Object *obj)
 #endif
     register_cpu_props(obj);
 }
+#endif
 
+#if defined(TARGET_RISCV32)
 static void rv32_tillitis_picorv32_cpu_init(Object *obj)
 {
     CPURISCVState *env = &RISCV_CPU(obj)->env;
+    RISCVCPU *cpu = RISCV_CPU(obj);
     /* TODO: We should set RVZMMUL instead of RVM. Looks like QEMU 7.2 will
      * have support for that. */
     set_misa(env, MXL_RV32, RVI | RVM | RVC);
-    qdev_prop_set_bit(DEVICE(obj), "mmu", false);
-    qdev_prop_set_bit(DEVICE(obj), "pmp", false);
+    register_cpu_props(obj);
+    cpu->cfg.mmu = false;
+    cpu->cfg.pmp = false;
 }
 #endif
 


### PR DESCRIPTION
Note that tillitis must be built WITHOUT `-DNOCONSOLE` in order for this to work.

Requires:

- https://github.com/tillitis/tillitis-key1/pull/117

Closes #13
