### PR TITLE
System reset

### DIFF
--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -71,6 +71,7 @@ struct TK1MachineClass {
     MachineClass parent_obj;
     /*< public >*/
     bool has_flash_access;
+    bool has_system_reset;
 };
 
 #define TYPE_TK1_MACHINE MACHINE_TYPE_NAME("tk1")


### PR DESCRIPTION
## Description

Adds a TK1_MMIO_TK1_SYSTEM_RESET hardware function at address 0xff0001c0. Writing to this address will reset the device.

The initialization of hardware functions is moved to a reset handler which is registered in the machine class.

Draft fix for #23 

## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
