### PR TITLE
tk1: new name of define to enable HTIF when building firmware

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -565,7 +565,7 @@ static void tk1_board_init(MachineState *machine)
     }
 
     if (s->htif_enabled) {
-        printf("Enabling HTIF (for debug output from firmware, which must be built *without* -DNOCONSOLE)\n");
+        printf("Enabling HTIF (for debug output from firmware, which must be built with -DQEMU_CONSOLE)\n");
         riscv_load_firmware(machine->firmware, memmap[TK1_ROM].base, htif_symbol_callback);
         htif_mm_init(sys_mem, serial_hd(0), 0, 0);
     } else {


### PR DESCRIPTION
## Description

Change of name of the define that enables HTIF when building firmware.
See PR https://github.com/tillitis/tillitis-key1/pull/263

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.
- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
