### PR TITLE
tk1: update names of RAM randomization API

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -236,11 +236,11 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
         }
 
         return;
-    case TK1_MMIO_TK1_RAM_ASLR:
-        badmsg = "unimplemented: write to RAM_ASLR";
+    case TK1_MMIO_TK1_RAM_ADDR_RAND:
+        badmsg = "unimplemented: write to RAM_ADDR_RAND";
         break;
-    case TK1_MMIO_TK1_RAM_SCRAMBLE:
-        badmsg = "unimplemented: write to RAM_SCRAMBLE";
+    case TK1_MMIO_TK1_RAM_DATA_RAND:
+        badmsg = "unimplemented: write to RAM_DATA_RAND";
         break;
     case TK1_MMIO_TK1_CPU_MON_CTRL:
         badmsg = "unimplemented: write to CPU_MON_CTRL";


### PR DESCRIPTION
## Description

The names where updated a while back, keep qemu in sync.
Commit 53c5e70 in tillitis-key1

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
