### PR TITLE
Increase Castor machine fw ram size to 4 kByte

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -115,7 +115,7 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
 
     // Byte addressable
     if (addr >= TK1_MMIO_FW_RAM_BASE
-        && (addr + size) <= (TK1_MMIO_FW_RAM_BASE + TK1_MMIO_FW_RAM_SIZE)) {
+        && (addr + size) <= (TK1_MMIO_FW_RAM_BASE + tmc->fw_ram_size)) {
         if (s->app_mode) {
             badmsg = "write to FW_RAM in app-mode";
             goto bad;
@@ -267,6 +267,7 @@ bad:
 static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
 {
     TK1State *s = opaque;
+    TK1MachineClass *tmc = TK1_MACHINE_GET_CLASS(s);
     uint8_t r;
     const char *badmsg = "";
 
@@ -275,7 +276,7 @@ static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
 
     // Byte addressable
     if (addr >= TK1_MMIO_FW_RAM_BASE
-        && (addr + size) <= (TK1_MMIO_FW_RAM_BASE + TK1_MMIO_FW_RAM_SIZE)) {
+        && (addr + size) <= (TK1_MMIO_FW_RAM_BASE + tmc->fw_ram_size)) {
         if (s->app_mode) {
             badmsg = "read from FW_RAM in app-mode";
             goto bad;
@@ -629,6 +630,7 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     mc->default_ram_size = tk1_memmap[TK1_RAM].size;
     tmc->has_flash_access = false;
     tmc->has_system_reset = false;
+    tmc->fw_ram_size = TK1_BELLATRIX_FW_RAM_SIZE;
 
     object_class_property_add_str(oc, "fifo",
                                   tk1_machine_get_chardev,
@@ -647,6 +649,7 @@ static void tk1_castor_machine_class_init(ObjectClass *oc, void *data)
     mc->desc = "Tillitis TK1 Castor Board";
     tmc->has_flash_access = true;
     tmc->has_system_reset = true;
+    tmc->fw_ram_size = TK1_CASTOR_FW_RAM_SIZE;
 }
 
 static const TypeInfo tk1_machine_types[] = {

--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -31,6 +31,8 @@
 #define TK1_CLOCK_FREQ 18000000
 #define TK1_RX_FIFO_SIZE 16
 #define TK1_SPI_BASE TK1_MMIO_TK1_SPI_EN
+#define TK1_BELLATRIX_FW_RAM_SIZE 0x800
+#define TK1_CASTOR_FW_RAM_SIZE 0x1000
 
 typedef struct TK1State {
     /*< private >*/
@@ -57,7 +59,7 @@ typedef struct TK1State {
     uint32_t blake2s;
     uint8_t cdi[32];
     uint32_t udi[2]; // 8 bytes
-    uint8_t fw_ram[TK1_MMIO_FW_RAM_SIZE];
+    uint8_t fw_ram[TK1_CASTOR_FW_RAM_SIZE];
     uint32_t timer_initial;
     uint32_t timer;
     uint32_t timer_prescaler;
@@ -72,6 +74,7 @@ struct TK1MachineClass {
     /*< public >*/
     bool has_flash_access;
     bool has_system_reset;
+    uint32_t fw_ram_size;
 };
 
 #define TYPE_TK1_MACHINE MACHINE_TYPE_NAME("tk1")


### PR DESCRIPTION
## Description

Increases the FW RAM size of the tk1-castor machine to the same size as current main in tillitis/tillitis-key1. The size is increased to 4 kByte.

## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
