### PR TITLE
Add syscall trigger address

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -102,6 +102,7 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
 {
     TK1State *s = opaque;
     TK1MachineClass *tmc = TK1_MACHINE_GET_CLASS(s);
+    CPURISCVState *env = &s->cpus.harts[0].env;
     uint8_t c = val;
     const char *badmsg = "";
 
@@ -111,6 +112,28 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
     if (addr == TK1_MMIO_QEMU_DEBUG) {
         putchar(c);
         return;
+    }
+
+    if (tmc->has_syscall) {
+        if (addr == TK1_MMIO_SYSCALL) {
+            // TKey implements system calls using the non-standard interrupts
+            // provided by the PicoRV32 processor. Lacking a better option we
+            // modify the cpu registers here directly.
+            //
+            // Return address is stored in x3.
+            // IRQ flags are stored in x4.
+
+            // Assume the current address is 32-bit and store next pc in x3.
+            env->gpr[3] = env->pc + 4;
+            env->gpr[4] = TK1_SYSCALL_IRQ_MASK;
+            // Jump to interrupt handle by updating pc from under the feet of
+            // the CPU. Qemu probably does something like 'pc +=
+            // current_instruction_length' later so we take our interrupt
+            // handler address and subtract 4.
+            // This could probably be handled by adding an interrupt controller.
+            env->pc = TK1_IRQ_HANDLER_ADDRESS - 4;
+            return;
+        }
     }
 
     // Byte addressable
@@ -629,6 +652,7 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     mc->default_ram_id = "riscv.tk1.ram";
     mc->default_ram_size = tk1_memmap[TK1_RAM].size;
     tmc->has_flash_access = false;
+    tmc->has_syscall = false;
     tmc->has_system_reset = false;
     tmc->fw_ram_size = TK1_BELLATRIX_FW_RAM_SIZE;
 
@@ -648,6 +672,7 @@ static void tk1_castor_machine_class_init(ObjectClass *oc, void *data)
 
     mc->desc = "Tillitis TK1 Castor Board";
     tmc->has_flash_access = true;
+    tmc->has_syscall = true;
     tmc->has_system_reset = true;
     tmc->fw_ram_size = TK1_CASTOR_FW_RAM_SIZE;
 }

--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -33,6 +33,9 @@
 #define TK1_SPI_BASE TK1_MMIO_TK1_SPI_EN
 #define TK1_BELLATRIX_FW_RAM_SIZE 0x800
 #define TK1_CASTOR_FW_RAM_SIZE 0x1000
+#define TK1_IRQ_HANDLER_ADDRESS 0x10
+#define TK1_SYSCALL_IRQ_MASK (1 << 31)
+#define TK1_MMIO_SYSCALL 0xe1000000
 
 typedef struct TK1State {
     /*< private >*/
@@ -73,6 +76,7 @@ struct TK1MachineClass {
     MachineClass parent_obj;
     /*< public >*/
     bool has_flash_access;
+    bool has_syscall;
     bool has_system_reset;
     uint32_t fw_ram_size;
 };


### PR DESCRIPTION
## Description

This PR implements  the syscall trigger address at `0xe1000000`. Writes to this address will set the `pc` register to the syscall handler address, `x3` to the interrupt return address, and set `x4` to the syscall irq mask.

The TKey implements syscalls using non-riscv-standard interrupts which does not fit the RISC-V interrupt model. For the now we implement syscall trigger address by directly modifying CPU registers from the machine.

This doesn't add support for the PicoRV32 custom instructions `picorv32_retirq_insn` and `picorv32_maskirq_insn` so that needs to be handled in firmware. As a workaround [qemu_firmware.elf](https://github.com/tillitis/tillitis-key1/tree/TK1-Castor-alpha-1) in Castor-alpha1 use `mv ra, x3; ret` as a standin for `picorv32_retirq_insn` and `picorv32_maskirq_insn` is not called at all.

Privilege level handling is not implemented.

Relates to #33

## Type of change

- [x] Feature (non breaking change which adds functionality)