### PR TITLE
tk1: Set TK1_MMIO_TK1_VERSION content to 6 on Castor

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -409,7 +409,7 @@ static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
     case TK1_MMIO_TK1_NAME1:
         return 0x6d6b6466; // "mkdf"
     case TK1_MMIO_TK1_VERSION:
-        return 1;
+        return tmc->version;
     case TK1_MMIO_TK1_SWITCH_APP:
         if (s->app_mode) {
             return 0xffffffff;
@@ -655,6 +655,7 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     tmc->has_syscall = false;
     tmc->has_system_reset = false;
     tmc->fw_ram_size = TK1_BELLATRIX_FW_RAM_SIZE;
+    tmc->version = 1;
 
     object_class_property_add_str(oc, "fifo",
                                   tk1_machine_get_chardev,
@@ -675,6 +676,7 @@ static void tk1_castor_machine_class_init(ObjectClass *oc, void *data)
     tmc->has_syscall = true;
     tmc->has_system_reset = true;
     tmc->fw_ram_size = TK1_CASTOR_FW_RAM_SIZE;
+    tmc->version = 6;
 }
 
 static const TypeInfo tk1_machine_types[] = {

--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -79,6 +79,7 @@ struct TK1MachineClass {
     bool has_syscall;
     bool has_system_reset;
     uint32_t fw_ram_size;
+    uint32_t version;
 };
 
 #define TYPE_TK1_MACHINE MACHINE_TYPE_NAME("tk1")


### PR DESCRIPTION
## Description

Sets `TK1_MMIO_TK1_VERSION` content to 6 when running `qemu-system-riscv32` with `-M tk1-castor`. Matches change in https://github.com/tillitis/tillitis-key1/commit/2556f61f5abd68375571786103c7987beccbda61#diff-8424cbde5758a3563740d571976ee73b0c0ab181af88daf2ca9ebd8ea1045706L104.

Tested by running qemu_firmware.bin built from main (https://github.com/tillitis/tillitis-key1/commit/aa04cf068f2f440d3a91eb9a503343b50c1de2a2). Output:

```
(qemu) Hello, I'm firmware with tk1_name0:0x746b3120 tk1_name1:0x6d6b6466 tk1_version:0x00000006
```

## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
