### PR TITLE
Add --symlink option to usb_mux

### DIFF
--- a/tools/tk1/qemu_usb_mux.py
+++ b/tools/tk1/qemu_usb_mux.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import atexit
 import fcntl
 import os
 import pty
@@ -67,7 +68,9 @@ def main():
         if args.verbose or not args.symlink:
             print(f"{name} PTY created at: {path}")
         if args.symlink:
-            os.symlink(path, f"{args.symlink}-{name}.pty")
+            linkname = f"{args.symlink}-{name}.pty"
+            os.symlink(path, linkname)
+            atexit.register(os.remove, linkname)
         frame_fds[code] = fd
         fd_to_frame[fd] = code
 

--- a/tools/tk1/qemu_usb_mux.py
+++ b/tools/tk1/qemu_usb_mux.py
@@ -43,13 +43,14 @@ def create_pty(name):
     fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     slave_name = os.ttyname(slave)
-    print(f"{name} PTY created at: {slave_name}")
     return master, slave_name
 
 def main():
     parser = argparse.ArgumentParser(description="Open PTY endpoints that adds framing for QEMU communication")
     parser.add_argument("pty_path", help="Path to the QEMU char device PTY (e.g., /dev/pts/X)")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    parser.add_argument("-s", "--symlink", help="Create symlinks to the new ptys", metavar="prefix")
+
     args = parser.parse_args()
 
     try:
@@ -63,6 +64,10 @@ def main():
     fd_to_frame = {}
     for name, code in FRAMES.items():
         fd, path = create_pty(name)
+        if args.verbose or not args.symlink:
+            print(f"{name} PTY created at: {path}")
+        if args.symlink:
+            os.symlink(path, f"{args.symlink}-{name}.pty")
         frame_fds[code] = fd
         fd_to_frame[fd] = code
 
@@ -135,4 +140,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Description

Add a `--symlink` option to `qemu_usb_mux.py`, to get predictable names for the created slave PTYs.

Example usage: https://git.glasklar.is/nisse/tkey-sigsum-apps/-/blob/293a39917ac4da2992df65aa8d0f1decde9edd20/scripts/qemu.sh#L48

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
