### PR TITLE
Delete code to usb_mux set slave PTYs to non-blocking

### DIFF
--- a/tools/tk1/qemu_usb_mux.py
+++ b/tools/tk1/qemu_usb_mux.py
@@ -34,10 +34,6 @@ def create_pty(name):
     # Set slave PTY to raw mode (disables buffering, canonical mode, etc.)
     tty.setraw(slave)
 
-    # Set slave to non-blocking
-    flags = fcntl.fcntl(slave, fcntl.F_GETFL)
-    fcntl.fcntl(slave, fcntl.F_SETFL, flags | os.O_NONBLOCK)
-
     # Set master to non-blocking
     flags = fcntl.fcntl(master, fcntl.F_GETFL)
     fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)


### PR DESCRIPTION
## Description

As far as I understand, the file status flag O_NON_BLOCK only affects this process' use of the fd, and other processes that inherit it in some way or the other. But here, the fd isn't used after tty.setraw(slave). Other processes, e.g., tkey-runapp, will open the slave pty by name, and it then gets its own fd and set of file status flags.

(It still seems the slave pty fd needs to be kept open, even though it is unused and leaked after create_pty returns. I'm not sure how to refactor the program to be able to just close this apparently unused fd immediately after `.setraw`).

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
