### PR TITLE
Override default ram size

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -550,10 +550,9 @@ static void tk1_board_init(MachineState *machine)
     }
 
     if (machine->ram_size != mc->default_ram_size) {
-        char *sz = size_to_str(mc->default_ram_size);
-        error_report("Invalid RAM size, should be %s.", sz);
+        char *sz = size_to_str(machine->ram_size);
+        error_report("Default RAM size is overridden. Size %s.", sz);
         g_free(sz);
-        exit(EXIT_FAILURE);
     }
 
     if (strcmp(machine->cpu_type, TYPE_RISCV_CPU_TILLITIS_PICORV32) != 0) {


### PR DESCRIPTION
## Description

Make app RAM size configurable via `-m <size>' to qemu.
Gives a nice printout that the default size is overridden. 

If running with 

```
qemu-system-riscv32 \
-m 1M \
-nographic \
-M tk1-castor,fifo=chrid \
....
```

We can see that we get RAM with size `0xfffff`
```
info mtree
address-space: I/O
  0000000000000000-000000000000ffff (prio 0, i/o): io

address-space: cpu-memory-0
address-space: memory
  0000000000000000-ffffffffffffffff (prio 0, i/o): system
    0000000000000000-000000000001ffff (prio 0, rom): riscv.tk1.rom
    0000000040000000-00000000400fffff (prio 0, ram): riscv.tk1.ram
    00000000c0000000-00000000fffffffe (prio 0, i/o): riscv.tk1.mmio
    00000000ff000200-00000000ff000211 (prio 0, i/o): tk1.spi
```

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.
- [x] Feature (non breaking change which adds functionality)


## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
