### PR TITLE
Timer: fix return value, and restart with inital value

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -230,19 +230,18 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
             break;
         }
         s->timer_initial = val;
-        s->timer = val;
         return;
     case TK1_MMIO_TIMER_CTRL:
         if (s->timer_running) {
             if (val & (1 << TK1_MMIO_TIMER_CTRL_STOP_BIT)) {
-                // Stop. Reset to initial value.
+                // Stop.
                 s->timer_running = false;
-                s->timer = s->timer_initial;
             }
             // Start timer when already running does nothing
         } else {
             if (val & (1 << TK1_MMIO_TIMER_CTRL_START_BIT)) {
-                // Start and schedule next tick
+                // Start, set timer to initial value and schedule next tick
+                s->timer = s->timer_initial;
                 s->timer_running = true;
                 timer_mod(s->qtimer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + s->timer_interval);
             }

--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -374,7 +374,11 @@ static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
         return entropy;
 
     case TK1_MMIO_TIMER_TIMER: // u32
-        return s->timer;
+        if (!s->timer_running) {
+            return s->timer_initial;
+        } else {
+            return s->timer;
+        }
     case TK1_MMIO_TIMER_PRESCALER:
         return s->timer_prescaler;
     case TK1_MMIO_TIMER_STATUS:


### PR DESCRIPTION
## Description

Two bugs in the timer implementation in qemu:
1) the return value of TIMER_TIMER should be the initial value, as hw, if it is not running.
2) when the timer has finished, one should be able to start the timer again and it would use the last written initial value, as hardware.

The bugs can be tested with the branch `test_timer_in_qemu`, in tillitis-key1. It is a slightly modified testapp.

1) run in qemu from tk1 branch, and both errors will occur.
2) run i qemu on this branch and see that both bugs are fixed
3) can also run this on actual hardware and see that it is the same as this fixed branch.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
