### PR TITLE
tk1: Move Castor UDS

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -160,7 +160,7 @@ static void tk1_mmio_write(void *opaque, hwaddr addr, uint64_t val, unsigned siz
     }
 
     // Handle some read-only addresses first
-    if (addr >= TK1_MMIO_UDS_FIRST && addr <= TK1_MMIO_UDS_LAST) {
+    if (addr >= tmc->mmio_uds_first_addr && addr <= tmc->mmio_uds_last_addr) {
         badmsg = "write to UDS";
         goto bad;
     }
@@ -336,12 +336,12 @@ static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
     // read-once implementation is word-based (4 bytes), it is in practice not
     // possible to read all 4 bytes of a word -- the 3 last bytes read would
     // just be zeros. Therefore we only implement word-reading here.
-    if (addr >= TK1_MMIO_UDS_FIRST && addr <= TK1_MMIO_UDS_LAST) {
+    if (addr >= tmc->mmio_uds_first_addr && addr <= tmc->mmio_uds_last_addr) {
         if (s->app_mode) {
             badmsg = "read from UDS in app-mode";
             goto bad;
         }
-        int i = (addr - TK1_MMIO_UDS_FIRST) / 4;
+        int i = (addr - tmc->mmio_uds_first_addr) / 4;
         // Should only be read once
         if (s->block_uds[i]) {
             badmsg = "read from UDS twice";
@@ -685,6 +685,8 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     tmc->has_syscall = false;
     tmc->has_system_reset = false;
     tmc->fw_ram_size = TK1_BELLATRIX_FW_RAM_SIZE;
+    tmc->mmio_uds_first_addr = TK1_BELLATRIX_MMIO_UDS_FIRST;
+    tmc->mmio_uds_last_addr = TK1_BELLATRIX_MMIO_UDS_LAST;
     tmc->version = 1;
 
     object_class_property_add_str(oc, "fifo",
@@ -709,6 +711,8 @@ static void tk1_castor_machine_class_init(ObjectClass *oc, void *data)
     tmc->has_syscall = true;
     tmc->has_system_reset = true;
     tmc->fw_ram_size = TK1_CASTOR_FW_RAM_SIZE;
+    tmc->mmio_uds_first_addr = TK1_CASTOR_MMIO_UDS_FIRST;
+    tmc->mmio_uds_last_addr = TK1_CASTOR_MMIO_UDS_LAST;
     tmc->version = 6;
 }
 

--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -32,7 +32,11 @@
 #define TK1_RX_FIFO_SIZE 16
 #define TK1_SPI_BASE TK1_MMIO_TK1_SPI_EN
 #define TK1_BELLATRIX_FW_RAM_SIZE 0x800
+#define TK1_BELLATRIX_MMIO_UDS_FIRST 0xc2000040
+#define TK1_BELLATRIX_MMIO_UDS_LAST 0xc200005c
 #define TK1_CASTOR_FW_RAM_SIZE 0x1000
+#define TK1_CASTOR_MMIO_UDS_FIRST 0xc2000000
+#define TK1_CASTOR_MMIO_UDS_LAST 0xc200001c
 #define TK1_IRQ_HANDLER_ADDRESS 0x10
 #define TK1_SYSCALL_IRQ_MASK (1 << 31)
 #define TK1_MMIO_SYSCALL 0xe1000000
@@ -81,6 +85,8 @@ struct TK1MachineClass {
     bool has_syscall;
     bool has_system_reset;
     uint32_t fw_ram_size;
+    hwaddr mmio_uds_first_addr;
+    hwaddr mmio_uds_last_addr;
     uint32_t version;
 };
 


### PR DESCRIPTION
## Description

This PR changes the `tk1-castor` machine to use correct UDS address. The UDS has moved from `0xC2000040` on Bellatrix, to `0xC2000000` on Castor.

Testing was done using [testfw](https://github.com/tillitis/tillitis-key1/tree/107bbaa9ee389f69f05db5bdbba3e5789fc7e853/hw/application_fpga/fw/testfw). Before the change testfw reported:

```
FAIL: UDS empty

UDS: 0000000000000000000000000000000000000000000000000000000000000000
FAIL: UDS not equal to test UDS
```

After the change testfw no longer report UDS errors.

The behavior of the `tk1` (Bellatrix) machine is unchanged.

This will break any existing uses that rely on the Castor UDS being 0. Any testcases, using QEmu Castor, that assume a specific UDS, CDI or device app identity will break.
 
## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [x] QEMU is updated to reflect changes
