### PR TITLE
Set tk1-machine TK1_MMIO_TK1_VERSION content to value used in Bellatrix

### DIFF
--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -733,7 +733,7 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     tmc->fw_ram_size = TK1_BELLATRIX_FW_RAM_SIZE;
     tmc->mmio_uds_first_addr = TK1_BELLATRIX_MMIO_UDS_FIRST;
     tmc->mmio_uds_last_addr = TK1_BELLATRIX_MMIO_UDS_LAST;
-    tmc->version = 1;
+    tmc->version = 5;
     tmc->udi_vid = 0x1337;
     tmc->udi_pid = 0x2;
     tmc->udi_rev = 0x2;

--- a/hw/riscv/tk1.c
+++ b/hw/riscv/tk1.c
@@ -418,7 +418,7 @@ static uint64_t tk1_mmio_read(void *opaque, hwaddr addr, unsigned size)
     case TK1_MMIO_TK1_NAME1:
         return 0x6d6b6466; // "mkdf"
     case TK1_MMIO_TK1_VERSION:
-        return tmc->version;
+        return s->version;
     case TK1_MMIO_TK1_SWITCH_APP:
         if (s->app_mode) {
             return 0xffffffff;
@@ -520,6 +520,8 @@ static void tk1_reset(MachineState *machine, ShutdownCause reason)
     s->udi[0] |= ((udi_pid & 0x3f) << 6);
     s->udi[0] |= udi_rev & 0x3f;
     s->udi[1] = udi_serial;
+
+    s->version = s->version == -1 ? tmc->version : s->version;
 
     for (int i = 0; i < 32; i ++) {
         s->cdi[i] = 0;
@@ -636,6 +638,7 @@ static void tk1_machine_instance_init(Object *obj)
     s->udi_pid = -1;
     s->udi_rev = -1;
     s->udi_serial = -1;
+    s->version = -1;
 }
 
 static void tk1_machine_set_chardev(Object *obj,
@@ -707,6 +710,14 @@ static void tk1_machine_set_udi_serial(Object *obj, Visitor *v,
     visit_type_uint32(v, name, &s->udi_serial, errp);
 }
 
+static void tk1_machine_set_version(Object *obj, Visitor *v,
+                                    const char *name, void *opaque, Error **errp)
+{
+    TK1State *s = TK1_MACHINE(obj);
+
+    visit_type_uint32(v, name, &s->version, errp);
+}
+
 static void tk1_machine_instance_finalize(Object *obj)
 {
     TK1State *s = TK1_MACHINE(obj);
@@ -746,6 +757,12 @@ static void tk1_machine_class_init(ObjectClass *oc, void *data)
     object_class_property_add_bool(oc, "htif",
                                    NULL,
                                    tk1_machine_set_htif_enabled);
+
+    object_class_property_add(oc, "hw-version", "uint32_t",
+                              NULL, tk1_machine_set_version, NULL, NULL);
+    object_class_property_set_description(oc, "hw-version",
+                                          "Override default TK1_MMIO_TK1_VERSION content");
+
     object_class_property_add_bool(oc, "touch",
                                    NULL,
                                    tk1_machine_set_touch_sim_enabled);

--- a/include/hw/riscv/tk1.h
+++ b/include/hw/riscv/tk1.h
@@ -79,6 +79,7 @@ typedef struct TK1State {
     uint32_t udi_pid;
     uint32_t udi_rev;
     uint32_t udi_serial;
+    uint32_t version;
 } TK1State;
 
 struct TK1MachineClass {
@@ -91,11 +92,11 @@ struct TK1MachineClass {
     uint32_t fw_ram_size;
     hwaddr mmio_uds_first_addr;
     hwaddr mmio_uds_last_addr;
-    uint32_t version;
     uint32_t udi_vid;
     uint32_t udi_pid;
     uint32_t udi_rev;
     uint32_t udi_serial;
+    uint32_t version;
 };
 
 #define TYPE_TK1_MACHINE MACHINE_TYPE_NAME("tk1")


### PR DESCRIPTION
## Description

Updates the default `tk1`-machine `TK1_MMIO_TK1_VERSION` content to the value used in Bellatrix. 
tillitis/tillitis-key1 releases TK1-23.03 and onward use [version 5](https://github.com/tillitis/tillitis-key1/blob/TK1-23.03/hw/application_fpga/core/tk1/rtl/tk1.v#L90).

The `tk1-castor` machine is kept at version 6.

A `hw-version`-property is added for development, testing and backwards compatibility. This makes the version configurable when starting QEmu with: `-M tk1,hw-version=1,...` or similar.

## Type of change

- [x] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
